### PR TITLE
Add April 2026 cycle review documentation

### DIFF
--- a/docs/reviews/2026-04-cycle-review.md
+++ b/docs/reviews/2026-04-cycle-review.md
@@ -1,0 +1,32 @@
+# Cycle Review — April 2026
+
+## Summary
+This cycle focused on stabilizing CI/CD, aligning branch protection rules, and completing foundational backend and systemd work.
+
+## Completed
+- CI/CD workflows (backend tests, dashboard build, linting, Docker build, dependency scanning)
+- Backend health endpoint, error middleware, system data endpoint
+- Collector service + logging
+- Systemd services for backend and collector
+- Architecture and setup documentation
+
+## In Progress
+- Deployment workflow (real logic)
+- Release automation improvements
+- Dashboard status/error UI
+- Configuration system foundation
+
+## Ready / Unblocked
+- Dashboard UI epic
+- Backup system
+- Alerts
+- Analytics
+- Systemd enhancements
+- Collector improvements
+- Backend expansion
+
+## Notes & Insights
+- CI/CD is now stable and predictable
+- Repo hygiene improved significantly
+- Developer velocity increased
+- Next cycle should focus on visible dashboard improvements


### PR DESCRIPTION
Document the cycle review for April 2026, summarizing completed tasks, ongoing work, and insights.

Adds the April 2026 cycle review to /docs/reviews/.
Includes summary of completed items, in-progress work, and next-cycle goals.
