### PR TITLE
Add GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/backend_task.yml
+++ b/.github/ISSUE_TEMPLATE/backend_task.yml
@@ -1,0 +1,47 @@
+name: "Backend Task"
+description: "Create a backend engineering task"
+title: "Backend: <short description>"
+labels: ["backend"]
+projects: ["<your-org>/<your-project>"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: "Summary"
+      placeholder: "What backend change is needed?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: "Details"
+      description: "Describe the backend logic, endpoints, models, or queries involved"
+      placeholder: "- Update endpoint\n- Add model\n- Modify query"
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: "Requirements"
+      placeholder: "- Requirement 1\n- Requirement 2"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "Acceptance Criteria"
+      placeholder: "- AC 1\n- AC 2"
+
+  - type: input
+    id: feature
+    attributes:
+      label: "Feature"
+      placeholder: "Which feature does this task support?"
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priority"
+      options:
+        - High
+        - Medium
+        - Low

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,49 @@
+name: "Bug Report"
+description: "Report a bug in the system"
+title: "Bug: <short description>"
+labels: ["bug"]
+projects: ["<your-org>/<your-project>"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: "Summary"
+      placeholder: "What went wrong?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: "Steps to Reproduce"
+      placeholder: "1. Step one\n2. Step two\n3. Step three"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected Behavior"
+      placeholder: "What should have happened?"
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Actual Behavior"
+      placeholder: "What actually happened?"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs / Output"
+      placeholder: "Paste relevant logs or errors"
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "Severity"
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,53 @@
+name: "Feature"
+description: "Create a new feature-level issue"
+title: "Feature: <short description>"
+labels: ["feature"]
+projects: ["<your-org>/<your-project>"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: "Summary"
+      description: "What is the purpose of this feature?"
+      placeholder: "High-level description"
+    validations:
+      required: true
+
+  - type: textarea
+    id: goals
+    attributes:
+      label: "Goals"
+      description: "What should this feature accomplish?"
+      placeholder: "- Goal 1\n- Goal 2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: "Requirements"
+      description: "Functional and non-functional requirements"
+      placeholder: "- Requirement 1\n- Requirement 2"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "Acceptance Criteria"
+      description: "Conditions that must be met for this feature to be complete"
+      placeholder: "- AC 1\n- AC 2"
+
+  - type: input
+    id: epic
+    attributes:
+      label: "Epic"
+      description: "Which epic does this feature belong to?"
+      placeholder: "Systemd Services, Dashboard, Collector, etc."
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priority"
+      options:
+        - High
+        - Medium
+        - Low

--- a/.github/ISSUE_TEMPLATE/systemd.yml
+++ b/.github/ISSUE_TEMPLATE/systemd.yml
@@ -1,0 +1,47 @@
+name: "Systemd / DevOps Task"
+description: "Create a systemd or infrastructure task"
+title: "Systemd: <short description>"
+labels: ["systemd", "devops"]
+projects: ["<your-org>/<your-project>"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: "Summary"
+      placeholder: "What systemd or infrastructure change is needed?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: "Details"
+      description: "Describe the service, restart policy, logging, or dependency changes"
+      placeholder: "- Update service file\n- Add restart policy\n- Add watchdog"
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: "Requirements"
+      placeholder: "- Requirement 1\n- Requirement 2"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "Acceptance Criteria"
+      placeholder: "- AC 1\n- AC 2"
+
+  - type: input
+    id: epic
+    attributes:
+      label: "Epic"
+      placeholder: "Systemd Services, Deployment, etc."
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priority"
+      options:
+        - High
+        - Medium
+        - Low

--- a/.github/ISSUE_TEMPLATE/ui_task.yml
+++ b/.github/ISSUE_TEMPLATE/ui_task.yml
@@ -1,0 +1,47 @@
+name: "UI Task"
+description: "Create a frontend/UI task"
+title: "UI: <short description>"
+labels: ["ui"]
+projects: ["<your-org>/<your-project>"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: "Summary"
+      placeholder: "What UI component or page needs to be built?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: design
+    attributes:
+      label: "Design / Layout"
+      description: "Describe the UI structure, components, and interactions"
+      placeholder: "- Component structure\n- Layout\n- States"
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: "Requirements"
+      placeholder: "- Requirement 1\n- Requirement 2"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "Acceptance Criteria"
+      placeholder: "- AC 1\n- AC 2"
+
+  - type: input
+    id: feature
+    attributes:
+      label: "Feature"
+      placeholder: "Which feature does this UI task support?"
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priority"
+      options:
+        - High
+        - Medium
+        - Low


### PR DESCRIPTION
Adds standardized issue templates for Feature, Backend Task, UI Task, Systemd/DevOps, and Bug Report.
These templates will be used across all future issues and support consistent project structure.
