### PR TITLE
Backend/merge system panel data

### DIFF
--- a/backend_api/main.py
+++ b/backend_api/main.py
@@ -15,6 +15,8 @@ from fastapi import HTTPException
 from datetime import datetime
 from .health import get_backend_health, get_collector_health
 
+from .queries import get_merged_system_snapshot
+
 app = FastAPI(title="PVS6 Solar API")
 
 app.include_router(health_router)
@@ -106,14 +108,16 @@ def api_history_day_hourly(date: str):
 @app.get("/api/system/current")
 def api_system_current():
     try:
-        system = get_latest_system()
-        panels_raw = get_latest_panels()
+        # Use the new merged service function
+        merged = get_merged_system_snapshot()
 
-        if system is None:
+        if merged is None:
             raise HTTPException(status_code=500, detail="No system data available")
 
-        panels = [PanelSnapshot(**dict(row)) for row in panels_raw]
+        system = merged["system"]
+        panels = merged["panels"]
 
+        # Build the unified snapshot
         snapshot = {
             "system": {
                 "production_kw": system.production_kw,
@@ -142,7 +146,10 @@ def api_system_current():
         return snapshot
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to build system snapshot: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to build system snapshot: {e}"
+        )
 
 @app.get("/mode")
 def get_mode():

--- a/backend_api/queries.py
+++ b/backend_api/queries.py
@@ -2,6 +2,7 @@ import sqlite3
 from .models import SystemSnapshot
 from datetime import datetime, timedelta
 
+from .models import PanelSnapshot
 
 DB_PATH = "/home/pi/pvs6-monitor/pvs6_data.db"
 
@@ -178,3 +179,27 @@ def get_hourly_history(date_str: str):
         "consumption_kwh": [round(v, 3) for v in hourly_cons],
         "net_kwh": [round(v, 3) for v in hourly_net]
     }
+
+from .models import PanelSnapshot
+
+def get_merged_system_snapshot():
+    """
+    Returns a combined structure containing:
+    - latest system metrics (SystemSnapshot)
+    - latest panel metrics (list[PanelSnapshot])
+    """
+
+    system = get_latest_system()
+    panels_raw = get_latest_panels()
+
+    if system is None:
+        return None
+
+    # Convert DB rows → PanelSnapshot objects
+    panels = [PanelSnapshot(**dict(row)) for row in panels_raw]
+
+    return {
+        "system": system,
+        "panels": panels
+    }
+

--- a/backend_api/queries.py
+++ b/backend_api/queries.py
@@ -180,8 +180,6 @@ def get_hourly_history(date_str: str):
         "net_kwh": [round(v, 3) for v in hourly_net]
     }
 
-from .models import PanelSnapshot
-
 def get_merged_system_snapshot():
     """
     Returns a combined structure containing:


### PR DESCRIPTION
# Backend: Use merged system + panel service in `/api/system/current`

## Summary
This PR updates the `/api/system/current` endpoint to use the new
`get_merged_system_snapshot()` backend service. This centralizes the logic
for merging system-level and panel-level data, keeping the endpoint clean
and ensuring consistent behavior across future features.

## What Changed
- Replaced manual calls to `get_latest_system()` and `get_latest_panels()`
- Endpoint now calls `get_merged_system_snapshot()` from `queries.py`
- Removed duplicate panel conversion logic
- Endpoint now receives a unified `{ system, panels }` structure

## Why This Matters
- Keeps backend logic in one place (queries.py)
- Reduces duplication across endpoints
- Supports the Current System Page feature
- Prepares backend for future analytics and history endpoints
- Matches the flat, minimal backend architecture

## Testing
- Hit `/api/system/current` on the Pi after pulling this branch
- Confirm system + panel data appear correctly
- Confirm health metadata still loads
- Confirm no regressions in panel scoring

## Related Issues
- Part of **Current System Page** feature
- Supports Backend Issue: Merge system + panel data
