### PR TITLE
UI/current system page

### DIFF
--- a/solar-dashboard/src/pages/CurrentSystemPage.vue
+++ b/solar-dashboard/src/pages/CurrentSystemPage.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="current-system-page">
+    <h1>Current System</h1>
+    <p>Loading system snapshot…</p>
+  </div>
+</template>
+
+<script setup>
+// No logic yet — next issue will add API call
+</script>
+
+<style scoped>
+.current-system-page {
+  padding: 1rem;
+}
+</style>

--- a/solar-dashboard/src/router/index.ts
+++ b/solar-dashboard/src/router/index.ts
@@ -1,8 +1,15 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import CurrentSystemPage from '../pages/CurrentSystemPage.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  routes: [],
+  routes: [
+    {
+      path: '/current-system',
+      name: 'CurrentSystem',
+      component: CurrentSystemPage
+    }
+  ],
 })
 
 export default router

--- a/solar-dashboard/src/router/index.ts
+++ b/solar-dashboard/src/router/index.ts
@@ -1,15 +1,18 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 import CurrentSystemPage from '../pages/CurrentSystemPage.vue'
+
+const routes: Array<RouteRecordRaw> = [
+  {
+    path: '/current-system',
+    name: 'CurrentSystem',
+    component: CurrentSystemPage
+  }
+]
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  routes: [
-    {
-      path: '/current-system',
-      name: 'CurrentSystem',
-      component: CurrentSystemPage
-    }
-  ],
+  routes
 })
 
 export default router
+


### PR DESCRIPTION
# **PR Description — Add “Current System” Page Route**

## Summary  
This PR introduces the initial UI foundation for the **Current System Page**. It adds a dedicated page component and registers a new route in the Vue Router, enabling navigation to `/current-system`. This establishes the entry point for all subsequent UI work related to the Current System dashboard.

## What’s Included  
- Created new `src/pages/CurrentSystemPage.vue` page component  
- Added `/current-system` route to `src/router/index.ts`  
- Verified TypeScript‑compatible router configuration  
- Ensured the page renders correctly as a standalone view  
- Established the folder structure (`src/pages/`) for future dashboard pages

## Why This Matters  
This is the first UI slice for the Current System feature. It provides the structural foundation needed for upcoming tasks, including:  
- Adding the system snapshot API hook  
- Rendering system summary cards  
- Displaying panel grid and health indicators  
- Implementing loading and error states  

By merging this PR, the feature branch gains a clean, navigable page where future UI components can be layered in vertically.

## Testing  
- Navigate to `/current-system` in the browser  
- Confirm the placeholder page renders  
- Confirm no router errors occur  
- Confirm TypeScript build passes  

## Related Work  
- Part of **Feature: Current System Page**  
- Follows backend issues already merged into the feature branch  
- Precedes UI Issue: Add API hook (`useSystemSnapshot`)

---

If you want, I can also generate the **next UI issue**, the **branch name**, and the **starter TypeScript hook** so you can keep momentum rolling.