### PR TITLE
UI: Wire System Summary Cards to `/api/system/current`

### DIFF
--- a/solar-dashboard/src/components/CurrentSystemPage.vue
+++ b/solar-dashboard/src/components/CurrentSystemPage.vue
@@ -3,12 +3,36 @@
 
     <h1 class="text-2xl font-bold">Current System Status</h1>
 
-    <!-- System Summary Cards -->
-    <div class="flex gap-4 flex-wrap">
-      <SystemSummaryCard label="Solar Generation" value="0.00" unit="kW" />
-      <SystemSummaryCard label="Home Load" value="0.00" unit="kW" />
-      <SystemSummaryCard label="Net Power" value="0.00" unit="kW" />
-      <SystemSummaryCard label="Grid Import/Export" value="0.00" unit="kW" />
+    <!-- Loading -->
+    <p v-if="loading">Loading system snapshot…</p>
+
+    <!-- Error -->
+    <p v-else-if="error" class="text-red-600">
+      Failed to load system snapshot: {{ error }}
+    </p>
+
+    <!-- Summary Cards -->
+    <div v-else class="flex gap-4 flex-wrap">
+      <SystemSummaryCard
+        label="Solar Generation"
+        :value="snapshot.solar_kw"
+        unit="kW"
+      />
+      <SystemSummaryCard
+        label="Home Load"
+        :value="snapshot.load_kw"
+        unit="kW"
+      />
+      <SystemSummaryCard
+        label="Net Power"
+        :value="snapshot.net_kw"
+        unit="kW"
+      />
+      <SystemSummaryCard
+        label="Grid Import/Export"
+        :value="snapshot.grid_kw"
+        unit="kW"
+      />
     </div>
 
     <!-- Panel Grid -->
@@ -18,6 +42,13 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
+import { useSystemSnapshot } from '../composables/useSystemSnapshot'
+
 import SystemSummaryCard from '../components/SystemSummaryCard.vue'
 import PanelGrid from '../components/PanelGrid.vue'
+
+const { data, loading, error } = useSystemSnapshot()
+
+const snapshot = computed(() => data.value || {})
 </script>

--- a/solar-dashboard/src/composables/useSystemSnapshot.ts
+++ b/solar-dashboard/src/composables/useSystemSnapshot.ts
@@ -1,0 +1,34 @@
+import { ref, onMounted } from 'vue'
+
+export function useSystemSnapshot() {
+  const data = ref(null)
+  const loading = ref(true)
+  const error = ref(null)
+
+  async function fetchSnapshot() {
+    loading.value = true
+    error.value = null
+
+    try {
+      const res = await fetch('/api/system/current')
+      if (!res.ok) throw new Error('Failed to fetch system snapshot')
+
+      data.value = await res.json()
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  onMounted(() => {
+    fetchSnapshot()
+  })
+
+  return {
+    data,
+    loading,
+    error,
+    refresh: fetchSnapshot
+  }
+}


### PR DESCRIPTION
UI: Wire System Summary Cards to `/api/system/current`

**Summary**  
This PR adds the first layer of backend integration for the Current System page by wiring the System Summary Cards to the `/api/system/current` endpoint. The page now loads real system snapshot data, displays loading and error states, and provides a clean foundation for future enhancements such as auto‑refresh, status indicators, and panel‑level data.

**What’s Included**  
- Added `useSystemSnapshot.ts` composable to manage fetch, loading, error, and refresh logic  
- Updated `CurrentSystemPage.vue` to consume live data from the composable  
- Implemented loading state (“Loading system snapshot…”)  
- Implemented error state with friendly messaging  
- Bound real values to the four summary cards:  
  - Solar Generation  
  - Home Load  
  - Net Power  
  - Grid Import/Export  
- Preserved existing layout and panel grid components  
- Ensured the page remains functional even when backend is unavailable  

**Why This Matters**  
This slice transitions the Current System page from static UI to a live, data‑driven dashboard. It establishes the data‑flow pattern for all future system‑level UI components and ensures the frontend can gracefully handle backend latency or outages.

**Next Steps (Future PRs)**  
- Add auto‑refresh + timestamp  
- Wire panel grid to backend panel data  
- Add system status bar  
- Add color‑coding and health indicators  
- Add loading/error states for panel grid  

