### PR TITLE
Implement API endpoint for current system readings

### DIFF
--- a/backend_api/main.py
+++ b/backend_api/main.py
@@ -105,3 +105,35 @@ def get_mode():
     except (FileNotFoundError, OSError):
         return {"mode": "unknown"}
 
+@app.get("/api/system/current")
+def api_system_current():
+    import sqlite3
+    from .queries import DB_PATH  # adjust if DB_PATH is defined elsewhere
+
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+
+    cur.execute("""
+        SELECT timestamp, production_kw, consumption_kw, grid_kw
+        FROM readings
+        ORDER BY timestamp DESC
+        LIMIT 1
+    """)
+
+    row = cur.fetchone()
+    conn.close()
+
+    if not row:
+        return {"error": "no data"}
+
+    ts, solar, load, grid = row
+
+    return {
+        "timestamp": ts,
+        "solar_kw": solar,
+        "load_kw": load,
+        "net_kw": solar - load,
+        "grid_kw": grid
+    }
+
+


### PR DESCRIPTION
**Adds the `/api/system/current` backend endpoint to support the Current System page.**  
This endpoint returns the latest system snapshot from the `readings` table, including timestamp, solar production, load, net power, and grid import/export. It provides the data required for the frontend summary cards and completes the backend portion of the vertical slice.

### **Key changes**
- Added new FastAPI route: `GET /api/system/current`
- Queries the latest row from the `readings` table
- Returns normalized fields: `solar_kw`, `load_kw`, `net_kw`, `grid_kw`, `timestamp`
- Cleaned up backend service to ensure correct systemd unit (`pvs6-backend.service`) is used
- Verified endpoint registration via OpenAPI and curl

### **Why this change**
This endpoint enables the frontend Current System page to display real‑time system status and completes the backend portion of the feature slice.

### **Next steps**
- Wire the frontend summary cards to this endpoint  
- Implement auto‑refresh and error handling  
- Begin the panel grid + status bar slice  

---